### PR TITLE
Adding support for IRI-s in relationship values

### DIFF
--- a/webroot/content/specification/1.0.0/notify.json
+++ b/webroot/content/specification/1.0.0/notify.json
@@ -9,6 +9,15 @@
     "IngestAction": "coar-notify:IngestAction",
     "RelationshipAction": "coar-notify:RelationshipAction",
     "UnprocessableNotification": "coar-notify:UnprocessableNotification",
+    "as:subject": {
+      "@type": "@id"
+    },
+    "as:object": {
+      "@type": "@id"
+    },
+    "as:relationship": {
+      "@type": "@id"
+    },
     "ietf:cite-as": {
         "@type" : "@id"
     }

--- a/webroot/content/specification/1.0.1/notify.json
+++ b/webroot/content/specification/1.0.1/notify.json
@@ -9,6 +9,15 @@
     "IngestAction": "coar-notify:IngestAction",
     "RelationshipAction": "coar-notify:RelationshipAction",
     "UnprocessableNotification": "coar-notify:UnprocessableNotification",
+    "as:subject": {
+      "@type": "@id"
+    },
+    "as:object": {
+      "@type": "@id"
+    },
+    "as:relationship": {
+      "@type": "@id"
+    },
     "ietf:cite-as": {
         "@type" : "@id"
     }


### PR DESCRIPTION
Updating the JSON-LD context file to reflect that the values of the `as:subject`, `as:relationship` and `as:object` properties are IRIs.